### PR TITLE
Return `sass.NULL` when not handling the file

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "is-there": "^4.0.0",
-    "lodash": "^3.10.1"
+    "lodash": "^3.10.1",
+    "node-sass": "^3.0.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import _          from 'lodash';
 import {resolve}  from 'path';
 import isThere    from 'is-there';
+import sass       from 'node-sass';
 
 export default function(url, prev) {
   if (/\.json$/.test(url)) {
@@ -21,9 +22,7 @@ export default function(url, prev) {
       contents: parseJSON(require(files[0]))
     };
   } else {
-    return {
-      file: url
-    };
+    return sass.NULL;
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,26 +4,26 @@ import isThere    from 'is-there';
 import sass       from 'node-sass';
 
 export default function(url, prev) {
-  if (/\.json$/.test(url)) {
-    let includePaths = this.options.includePaths ? this.options.includePaths.split(':') : [];
-    let paths = []
-      .concat(prev.slice(0, prev.lastIndexOf('/')))
-      .concat(includePaths);
-
-    let files = paths
-      .map(path => resolve(path, url))
-      .filter(isThere);
-
-    if (files.length === 0) {
-      return new Error(`Unable to find "${url}" from the following path(s): ${paths.join(', ')}. Check includePaths.`);
-    }
-
-    return {
-      contents: parseJSON(require(files[0]))
-    };
-  } else {
+  if (!/\.json$/.test(url)) {
     return sass.NULL;
   }
+
+  let includePaths = this.options.includePaths ? this.options.includePaths.split(':') : [];
+  let paths = []
+    .concat(prev.slice(0, prev.lastIndexOf('/')))
+    .concat(includePaths);
+
+  let files = paths
+    .map(path => resolve(path, url))
+    .filter(isThere);
+
+  if (files.length === 0) {
+    return new Error(`Unable to find "${url}" from the following path(s): ${paths.join(', ')}. Check includePaths.`);
+  }
+
+  return {
+    contents: parseJSON(require(files[0]))
+  };
 }
 
 function parseJSON(json) {


### PR DESCRIPTION
According to the node-sass documentation:

> If an importer does not want to handle a particular path, it should
> return `sass.NULL`.

https://github.com/sass/node-sass#importer--v200---experimental

This will allow other importers to properly handle the import. Some more
discussion on this can be found at:

  https://github.com/jtangelder/sass-loader/pull/170#issuecomment-159374656

Since the documentation says that this is true as of 3.0.0, that's where
I set the dependency version.