### PR TITLE
Quote strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ function parseValue(value) {
   } else if (_.isPlainObject(value)) {
     return parseMap(value);
   } else {
-    return `"${value}"`;
+    return `unquote("${value}")`;
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ function parseValue(value) {
   } else if (_.isPlainObject(value)) {
     return parseMap(value);
   } else {
-    return value;
+    return `"${value}"`;
   }
 }
 


### PR DESCRIPTION
This should fix strings with parenthesis and the like.  For example, the .json file:

```javascript
{
  "breakpoints": {
    "alpha": "screen and (min-width: 560px)"
  }
}
```

would previously fail.