### PR TITLE
Hotfix to invalidate cache on every load

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ export default function(url, prev) {
   if (files.length === 0) {
     return new Error(`Unable to find "${url}" from the following path(s): ${paths.join(', ')}. Check includePaths.`);
   }
+  
+  delete require.cache[require.resolve(files[0])];
 
   return {
     contents: parseJSON(require(files[0]))


### PR DESCRIPTION
This would be a hotfix to fix issue #21.

It might not be an end-all solution, but it is functional with the current loading method.