### PR TITLE
Fix for recent versions of node-sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
-dist/
 *.sublime*

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,3 @@
-/src
-/test
 .editorconfig
 .gitignore
 .jshintrc

--- a/dist/node-sass-json-importer.js
+++ b/dist/node-sass-json-importer.js
@@ -1,0 +1,73 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _lodash = require('lodash');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+var _path = require('path');
+
+var _isThere = require('is-there');
+
+var _isThere2 = _interopRequireDefault(_isThere);
+
+exports['default'] = function (url, prev, done) {
+  if (!/\.json$/.test(url)) {
+    return done({
+      file: url
+    });
+  }
+
+  var includePaths = this.options.includePaths ? this.options.includePaths.split(':') : [];
+  var paths = [].concat(prev.slice(0, prev.lastIndexOf('/'))).concat(includePaths);
+
+  var file = paths.map(function (path) {
+    return (0, _path.resolve)(path, url);
+  }).filter(_isThere2['default']).pop();
+
+  if (!file) {
+    return new Error('Unable to find "' + url + '" from the following path(s): ' + paths.join(', ') + '. Check includePaths.');
+  }
+
+  // Prevent file from being cached by Node's `require` on continuous builds.
+  // https://github.com/Updater/node-sass-json-importer/issues/21
+  delete require.cache[require.resolve(file)];
+
+  return {
+    contents: parseJSON(require(file))
+  };
+};
+
+function parseJSON(json) {
+  return Object.keys(json).map(function (key) {
+    return '$' + key + ': ' + parseValue(json[key]) + ';';
+  }).join('\n');
+}
+
+function parseValue(value) {
+  if (_lodash2['default'].isArray(value)) {
+    return parseList(value);
+  } else if (_lodash2['default'].isPlainObject(value)) {
+    return parseMap(value);
+  } else {
+    return value;
+  }
+}
+
+function parseList(list) {
+  return '(' + list.map(function (value) {
+    return parseValue(value);
+  }).join(',') + ')';
+}
+
+function parseMap(map) {
+  return '(' + Object.keys(map).map(function (key) {
+    return key + ': ' + parseValue(map[key]);
+  }).join(',') + ')';
+}
+module.exports = exports['default'];

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 import _          from 'lodash';
 import {resolve}  from 'path';
 import isThere    from 'is-there';
-import sass       from 'node-sass';
 
-export default function(url, prev) {
+export default function(url, prev, done) {
   if (!/\.json$/.test(url)) {
-    return sass.NULL;
+    return done({
+      file: url
+    });
   }
 
   let includePaths = this.options.includePaths ? this.options.includePaths.split(':') : [];


### PR DESCRIPTION
This commit contains the relevant subset of changes from
https://github.com/mpalpha/node-sass-json-importer/commit/79a8393e3080a8e61123b41f146fcf784af5421d

Using the latest master commit for node-sass https://github.com/sass/node-sass/commit/11c96eee55d00c65d1ad1fddf6111bbb731aa789, I was not getting any CSS output for _any_ SCSS `@import`, .json or otherwise.

I noticed https://github.com/mpalpha/node-sass-json-importer/commit/79a8393e3080a8e61123b41f146fcf784af5421d was returning `done({ file: url })` instead of `sass.NULL`. I am not sure why, seeing as the node-sass importer docs say to return `NULL` in this instance, but I can verify that making this change solved my problem. All imports – SCSS partials and json – are working now.

I also needed to follow suit and remove `dist/` from the `.gitignore` and both `/src` and `/test` from the `.npmignore` to successfully install with npm 3.

For reference, I am using:
- node 5.6.0
- npm 3.7.1
- node-sass latest master https://github.com/sass/node-sass/commit/11c96eee55d00c65d1ad1fddf6111bbb731aa789