### PR TITLE
Improve sass strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prepublish": "npm run compile"
   },
   "dependencies": {
+    "is-color": "^0.2.0",
     "is-there": "^4.0.0",
     "lodash": "^3.10.1",
     "node-sass": "^3.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -26,8 +26,17 @@ export default function(url, prev) {
   // https://github.com/Updater/node-sass-json-importer/issues/21
   delete require.cache[require.resolve(file)];
 
+  var contents = require(file);
+  try {
+    if (/\.js$/.test(url)) {
+      contents = JSON.parse(JSON.stringify(contents));
+    }
+  } catch(e) {
+    return sass.NULL;
+  }
+
   return {
-    contents: parseJSON(require(file))
+    contents: parseJSON(contents)
   };
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import isThere    from 'is-there';
 import sass       from 'node-sass';
 
 export default function(url, prev) {
-  if (!/\.json$/.test(url)) {
+  if (!/\.(json|js)$/.test(url)) {
     return sass.NULL;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import _          from 'lodash';
 import {resolve}  from 'path';
 import isThere    from 'is-there';
 import sass       from 'node-sass';
+import isColor    from 'is-color';
 
 export default function(url, prev) {
   if (!/\.(json|js)$/.test(url)) {
@@ -40,6 +41,10 @@ export default function(url, prev) {
   };
 }
 
+function isCSSUnit(value) {
+  return /^\d*\.*\d+(em|ex|ch|rem|vh|vw|vmin|vmax|px|mm|cm|in|pt|pc|deg|grad|rad|turn|s|ms|Hz|kHz|dpi|dpcm|dppx)$/.test(value);
+}
+
 function parseJSON(json) {
   return Object.keys(json)
     .map(key => `$${key}: ${parseValue(json[key])};`)
@@ -52,7 +57,7 @@ function parseValue(value) {
   } else if (_.isPlainObject(value)) {
     return parseMap(value);
   } else {
-    return value;
+    return parseEndValue(value);
   }
 }
 
@@ -66,4 +71,12 @@ function parseMap(map) {
   return `(${Object.keys(map)
     .map(key => `${key}: ${parseValue(map[key])}`)
     .join(',')})`;
+}
+
+function parseEndValue(value) {
+  if (typeof value === 'string' && !isColor(value) && !isCSSUnit(value)) {
+    return JSON.stringify(value);
+  }
+
+  return value;
 }

--- a/test/fixtures/convert-strings/style-js.scss
+++ b/test/fixtures/convert-strings/style-js.scss
@@ -4,4 +4,6 @@ body {
   content: $string;
   color: $hex-color, $hsl-color, $rgba-color, $rgb-color, $css-color;
   font-size: $em-unit;
+  margin-top: #{$number}px;
+  margin-bottom: #{$float}em;
 }

--- a/test/fixtures/convert-strings/style-js.scss
+++ b/test/fixtures/convert-strings/style-js.scss
@@ -1,0 +1,7 @@
+@import 'variables.js';
+
+body {
+  content: $string;
+  color: $hex-color, $hsl-color, $rgba-color, $rgb-color, $css-color;
+  font-size: $em-unit;
+}

--- a/test/fixtures/convert-strings/style.scss
+++ b/test/fixtures/convert-strings/style.scss
@@ -1,0 +1,7 @@
+@import 'variables.json';
+
+body {
+  content: $string;
+  color: $hex-color, $hsl-color, $rgba-color, $rgb-color, $css-color;
+  font-size: $em-unit;
+}

--- a/test/fixtures/convert-strings/style.scss
+++ b/test/fixtures/convert-strings/style.scss
@@ -4,4 +4,6 @@ body {
   content: $string;
   color: $hex-color, $hsl-color, $rgba-color, $rgb-color, $css-color;
   font-size: $em-unit;
+  margin-top: #{$number}px;
+  margin-bottom: #{$float}em;
 }

--- a/test/fixtures/convert-strings/variables.js
+++ b/test/fixtures/convert-strings/variables.js
@@ -6,5 +6,7 @@ module.exports = {
   "css-color": "blue",
   "px-unit": "10px",
   "em-unit": "2.3em",
+  "number": 5,
+  "float": 5.5,
   "string": "Lorem ipsum, (\"foo\", bar)"
 }

--- a/test/fixtures/convert-strings/variables.js
+++ b/test/fixtures/convert-strings/variables.js
@@ -1,0 +1,10 @@
+module.exports = {
+  "hex-color": "#c33",
+  "hsl-color": "hsl(100, 100%, 100%)",
+  "rgba-color": "rgba(0, 0, 0, 1)",
+  "rgb-color": "rgb(10, 0, 0)",
+  "css-color": "blue",
+  "px-unit": "10px",
+  "em-unit": "2.3em",
+  "string": "Lorem ipsum, (\"foo\", bar)"
+}

--- a/test/fixtures/convert-strings/variables.json
+++ b/test/fixtures/convert-strings/variables.json
@@ -6,5 +6,7 @@
   "css-color": "blue",
   "px-unit": "10px",
   "em-unit": "2.3em",
+  "number": 5,
+  "float": 5.5,
   "string": "Lorem ipsum, (\"foo\", bar)"
 }

--- a/test/fixtures/convert-strings/variables.json
+++ b/test/fixtures/convert-strings/variables.json
@@ -1,0 +1,10 @@
+{
+  "hex-color": "#c33",
+  "hsl-color": "hsl(100, 100%, 100%)",
+  "rgba-color": "rgba(0, 0, 0, 1)",
+  "rgb-color": "rgb(10, 0, 0)",
+  "css-color": "blue",
+  "px-unit": "10px",
+  "em-unit": "2.3em",
+  "string": "Lorem ipsum, (\"foo\", bar)"
+}

--- a/test/fixtures/include-paths/style-js.scss
+++ b/test/fixtures/include-paths/style-js.scss
@@ -1,0 +1,5 @@
+@import 'variables.js';
+
+body {
+  color: $color-red;
+}

--- a/test/fixtures/include-paths/variables/variables.js
+++ b/test/fixtures/include-paths/variables/variables.js
@@ -1,0 +1,4 @@
+module.exports = {
+  "color-red": "#c33",
+  "color-blue": "#33c"
+}

--- a/test/fixtures/lists/style-js.scss
+++ b/test/fixtures/lists/style-js.scss
@@ -1,0 +1,5 @@
+@import 'variables.js';
+
+body {
+  color: nth($colors, 1);
+}

--- a/test/fixtures/lists/variables.js
+++ b/test/fixtures/lists/variables.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "colors": ["#c33", "#33c"]
+}

--- a/test/fixtures/maps/style-js.scss
+++ b/test/fixtures/maps/style-js.scss
@@ -1,0 +1,5 @@
+@import 'variables.js';
+
+body {
+  color: map-get($colors, red);
+}

--- a/test/fixtures/maps/variables.js
+++ b/test/fixtures/maps/variables.js
@@ -1,0 +1,5 @@
+module.exports = {
+  "colors": {
+    "red": "#c33"
+  }
+}

--- a/test/fixtures/strings/style-js.scss
+++ b/test/fixtures/strings/style-js.scss
@@ -1,0 +1,5 @@
+@import 'variables.js';
+
+body {
+  color: $color-red;
+}

--- a/test/fixtures/strings/variables.js
+++ b/test/fixtures/strings/variables.js
@@ -1,0 +1,4 @@
+module.exports = {
+  "color-red": "#c33",
+  "color-blue": "#33c"
+}

--- a/test/fixtures/wrong-js-export/style-js.scss
+++ b/test/fixtures/wrong-js-export/style-js.scss
@@ -1,0 +1,5 @@
+@import 'variables.js';
+
+body {
+  color: $color-red;
+}

--- a/test/fixtures/wrong-js-export/variables.js
+++ b/test/fixtures/wrong-js-export/variables.js
@@ -1,0 +1,4 @@
+module.exports = {
+  "color-red": function() {},
+  "color-blue": "#33c"
+}

--- a/test/index.js
+++ b/test/index.js
@@ -6,66 +6,75 @@ import {resolve}    from 'path';
 
 const EXPECTATION = 'body {\n  color: #c33; }\n';
 
+function sassRenderFile(opts = {}) {
+  return function(file) {
+    return sass.renderSync({
+      file: file,
+      importer: jsonImporter,
+      ...opts
+    });
+  }
+}
+
+function testExpectedCSS(result) {
+    expect(result.css.toString()).to.eql(EXPECTATION);
+}
+
+
 describe('Import type test', function() {
 
   it('imports strings', function() {
-    let result = sass.renderSync({
-      file: './test/fixtures/strings/style.scss',
-      importer: jsonImporter
-    });
-
-    expect(result.css.toString()).to.eql(EXPECTATION);
+    ['./test/fixtures/strings/style.scss',
+      './test/fixtures/strings/style-js.scss'
+    ].map(sassRenderFile()).forEach(testExpectedCSS);
   });
 
   it('imports lists', function() {
-    let result = sass.renderSync({
-      file: './test/fixtures/lists/style.scss',
-      importer: jsonImporter
-    });
-
-    expect(result.css.toString()).to.eql(EXPECTATION);
+    ['./test/fixtures/lists/style.scss',
+      './test/fixtures/lists/style-js.scss'
+    ].map(sassRenderFile()).forEach(testExpectedCSS);
   });
 
   it('imports maps', function() {
-    let result = sass.renderSync({
-      file: './test/fixtures/maps/style.scss',
-      importer: jsonImporter
-    });
-
-    expect(result.css.toString()).to.eql(EXPECTATION);
+    ['./test/fixtures/maps/style.scss',
+      './test/fixtures/maps/style-js.scss'
+    ].map(sassRenderFile()).forEach(testExpectedCSS);
   });
 
   it('finds imports via includePaths', function() {
-    let result = sass.renderSync({
-      file: './test/fixtures/include-paths/style.scss',
-      includePaths: ['./test/fixtures/include-paths/variables'],
-      importer: jsonImporter
-    });
-
-    expect(result.css.toString()).to.eql(EXPECTATION);
+    ['./test/fixtures/include-paths/style.scss',
+      './test/fixtures/include-paths/style-js.scss'
+    ].map(sassRenderFile({
+      includePaths: ['./test/fixtures/include-paths/variables']
+    })).forEach(testExpectedCSS);
   });
 
   it('finds imports via multiple includePaths', function() {
-    let result = sass.renderSync({
-      file: './test/fixtures/include-paths/style.scss',
-      includePaths: ['./test/fixtures/include-paths/variables', './some/other/path/'],
-      importer: jsonImporter
-    });
-
-    expect(result.css.toString()).to.eql(EXPECTATION);
+    ['./test/fixtures/include-paths/style.scss',
+      './test/fixtures/include-paths/style-js.scss'
+    ].map(sassRenderFile({
+      includePaths: ['./test/fixtures/include-paths/variables', './some/other/path/']
+    })).forEach(testExpectedCSS);
   });
 
   it(`throws when an import doesn't exist`, function() {
-    function render() {
-      sass.renderSync({
-        file: './test/fixtures/include-paths/style.scss',
-        includePaths: ['./test/fixtures/include-paths/foo'],
-        importer: jsonImporter
-      });
+    function render(file) {
+      return function() {
+        sass.renderSync({
+          file: file,
+          includePaths: ['./test/fixtures/include-paths/foo'],
+          importer: jsonImporter
+        });
+      }
     }
 
-    expect(render).to.throw(
+    expect(render('./test/fixtures/include-paths/style.scss')).to.throw(
       'Unable to find "variables.json" from the following path(s): ' +
+      `${resolve(process.cwd(), 'test/fixtures/include-paths')}, ./test/fixtures/include-paths/foo. ` +
+      'Check includePaths.'
+    );
+    expect(render('./test/fixtures/include-paths/style-js.scss')).to.throw(
+      'Unable to find "variables.js" from the following path(s): ' +
       `${resolve(process.cwd(), 'test/fixtures/include-paths')}, ./test/fixtures/include-paths/foo. ` +
       'Check includePaths.'
     );

--- a/test/index.js
+++ b/test/index.js
@@ -57,6 +57,17 @@ describe('Import type test', function() {
     })).forEach(testExpectedCSS);
   });
 
+  it(`JS imports do not export non valid JSON values`, function() {
+    function render() {
+      sass.renderSync({
+        file: './test/fixtures/wrong-js-export/style-js.scss',
+        importer: jsonImporter
+      });
+    }
+
+    expect(render).to.throw(`Undefined variable: "$color-red".`)
+  });
+
   it(`throws when an import doesn't exist`, function() {
     function render(file) {
       return function() {

--- a/test/index.js
+++ b/test/index.js
@@ -57,22 +57,21 @@ describe('Import type test', function() {
     })).forEach(testExpectedCSS);
   });
 
-  it('converts JS/JSON strings to Sass strings', function() {
+  it('quotes strings and preserves numbers, floats, colors, and values with units', function() {
     ['./test/fixtures/convert-strings/style-js.scss',
       './test/fixtures/convert-strings/style.scss'
     ].map(sassRenderFile()).forEach(function(result) {
-      expect(result.css.toString()).to.eql(`body {\n  content: 'Lorem ipsum, ("foo", bar)';\n  color: #c33, white, black, #0a0000, blue;\n  font-size: 2.3em; }\n`);
+      expect(result.css.toString()).to.eql(`body {\n  content: 'Lorem ipsum, ("foo", bar)';\n  color: #c33, white, black, #0a0000, blue;\n  font-size: 2.3em;\n  margin-top: 5px;\n  margin-bottom: 5.5em; }\n`);
     });
   });
 
-  it(`JS imports do not export non valid JSON values`, function() {
+  it(`strips non-valid JSON values from JS exports`, function() {
     function render() {
       sass.renderSync({
         file: './test/fixtures/wrong-js-export/style-js.scss',
         importer: jsonImporter
       });
     }
-
     expect(render).to.throw(`Undefined variable: "$color-red".`)
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -57,6 +57,14 @@ describe('Import type test', function() {
     })).forEach(testExpectedCSS);
   });
 
+  it('converts JS/JSON strings to Sass strings', function() {
+    ['./test/fixtures/convert-strings/style-js.scss',
+      './test/fixtures/convert-strings/style.scss'
+    ].map(sassRenderFile()).forEach(function(result) {
+      expect(result.css.toString()).to.eql(`body {\n  content: 'Lorem ipsum, ("foo", bar)';\n  color: #c33, white, black, #0a0000, blue;\n  font-size: 2.3em; }\n`);
+    });
+  });
+
   it(`JS imports do not export non valid JSON values`, function() {
     function render() {
       sass.renderSync({


### PR DESCRIPTION
From JSON strings, output quoted Sass strings except for valid CSS colors and number/floats with valid CSS units.

See the example below, JSON/JS at left, Sass output at right:

```
"hex-color": "#c33",                            //→ #c33
"hsl-color": "hsl(100, 100%, 100%)",            //→ hsl(100, 100%, 100%)
"rgba-color": "rgba(0, 0, 0, 1)",               //→ rgba(0, 0, 0, 1)
"rgb-color": "rgb(10, 0, 0)",                   //→ rgb(10, 0, 0)
"css-color": "blue",                            //→ blue
"px-unit": "10px",                              //→ 10px
"em-unit": "2.3em",                             //→ 2.3em
"string": "Lorem ipsum, (\"foo\", bar)"         //→ 'Lorem ipsum, ("foo", bar)'
"string2": "Lorem ipsum, ('foo', bar)"          //→ "Lorem ipsum, ('foo', bar)"
"quoted-number": "5"                            //→ "5"
```

Note that quoted numbers or floats are not unquoted in the output, because you can use numbers in JSON, but they could be unquoted just adding an `?` to the regex.

For the regex matching the CSS units I've taken all the units defined in mdn and in the libsass source code.

This PR is built on the top of #25 because it includes tests for JS imports too. #25 should be merged first.
It should fix problems mentioned in #5 and #16.

cc/ @pmowrer