### PR TITLE
Fix named exports breaking default CommonJS export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,3 +61,10 @@ export function parseMap(map) {
     .map(key => `${key}: ${parseValue(map[key])}`)
     .join(',')})`;
 }
+
+// Super-hacky: Override Babel's transpiled export to provide both
+// a default CommonJS export and named exports.
+// Fixes: https://github.com/Updater/node-sass-json-importer/issues/32
+// TODO: Remove in 3.0.0. Upgrade to Babel6.
+module.exports = exports.default;
+Object.keys(exports).forEach(key => module.exports[key] = exports[key]);

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,12 @@
 /* eslint-env mocha */
-import jsonImporter from '../src/index';
+import jsonImporter, {
+  isJSONfile
+}                   from '../src/index';
 import sass         from 'node-sass';
 import {expect}     from 'chai';
 import {resolve}    from 'path';
 
+const requiredImporter = require('../src/index');
 const EXPECTATION = 'body {\n  color: #c33; }\n';
 
 describe('Import type test', function() {
@@ -77,5 +80,20 @@ describe('Import type test', function() {
     });
 
     expect(result.css.toString()).to.eql(EXPECTATION);
+  });
+
+  // TODO: Added to verify named exports + CommonJS default export hack (see index.js).
+  it('provides the default export when using node require to import', function() {
+    let result = sass.renderSync({
+      file: './test/fixtures/strings/style.scss',
+      importer: requiredImporter
+    });
+
+    expect(result.css.toString()).to.eql(EXPECTATION);
+  });
+
+  // TODO: Added to verify named exports + CommonJS default export hack (see index.js).
+  it('provides named exports of internal methods', function() {
+    expect(isJSONfile('import.json')).to.be.true;
   });
 });


### PR DESCRIPTION
This is a temporary fix to restore broken behavior. Will be removed in 3.0.0.

[Fixes #32]