### PR TITLE
Add npm package link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-# node-sass-json-importer [![build status](https://travis-ci.org/Updater/node-sass-json-importer.svg?branch=master)](https://travis-ci.org/Updater/node-sass-json-importer)
+# node-sass-json-importer
+
 JSON importer for [node-sass](https://github.com/sass/node-sass). Allows `@import`ing `.json` files in Sass files parsed by `node-sass`.
+
+[![npm](https://img.shields.io/npm/v/node-sass-json-importer.svg)](https://www.npmjs.com/package/node-sass-json-importer)
+[![build status](https://travis-ci.org/Updater/node-sass-json-importer.svg?branch=master)](https://travis-ci.org/Updater/node-sass-json-importer)
 
 ## Usage
 ### [node-sass](https://github.com/sass/node-sass)


### PR DESCRIPTION
I know it's a tiny change, but this way when someone lands on the github page, it's easier to go to the npm project directly