### PR TITLE
Filter out invalid variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1.2
+* Filter out invalid variable names to prevent Sass compiler from crashing
+
+## 3.1.1
+* Return empty strings correctly to prevent Sass compiler from crashing
+
 ## 3.1.0
 * Add support for `.json5` files
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sass-json-importer",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Allows importing json in sass files parsed by node-sass.",
   "main": "dist/node-sass-json-importer.js",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -42,8 +42,13 @@ export function isJSONfile(url) {
 
 export function transformJSONtoSass(json) {
   return Object.keys(json)
+    .filter(key => isValidKey(key))
     .map(key => `$${key}: ${parseValue(json[key])};`)
     .join('\n');
+}
+
+export function isValidKey(key) {
+  return /^[^$@:].*/.test(key)
 }
 
 export function parseValue(value) {

--- a/test/fixtures-json5/invalid-variables/style.scss
+++ b/test/fixtures-json5/invalid-variables/style.scss
@@ -1,0 +1,5 @@
+@import 'variables.json5';
+
+body {
+  color: $colors;
+}

--- a/test/fixtures-json5/invalid-variables/variables.json5
+++ b/test/fixtures-json5/invalid-variables/variables.json5
@@ -1,0 +1,6 @@
+{
+  "colors": "",
+  "@not-valid": "123", // Not valid because of the leading @
+  ":not-valid": "123", // Not valid because of the leading :
+  "$not-valid": "123", // Not valid because of the leading $
+}

--- a/test/fixtures/invalid-variables/style.scss
+++ b/test/fixtures/invalid-variables/style.scss
@@ -1,0 +1,5 @@
+@import 'variables.json';
+
+body {
+  color: $colors;
+}

--- a/test/fixtures/invalid-variables/variables.json
+++ b/test/fixtures/invalid-variables/variables.json
@@ -1,0 +1,6 @@
+{
+  "colors": "",
+  "@not-valid": "123",
+  ":not-valid": "123",
+  "$not-valid": "123"
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,9 @@
 /* eslint-env mocha */
-import jsonImporter, {isJSONfile, parseValue} from '../src';
+import jsonImporter, {
+  isJSONfile,
+  isValidKey,
+  parseValue,
+} from '../src'
 import sass                                   from 'node-sass';
 import {expect}                               from 'chai';
 import {resolve}                              from 'path';
@@ -105,6 +109,15 @@ describe('Import type test (JSON)', function() {
 
     expect(result.css.toString()).to.eql('body {\n  color: ""; }\n');
   });
+
+  it('ignores variables starting with @, : or $', function() {
+    let result = sass.renderSync({
+      file: './test/fixtures/invalid-variables/style.scss',
+      importer: jsonImporter,
+    });
+
+    expect(result.css.toString()).to.eql('body {\n  color: ""; }\n');
+  });
 });
 
 describe('Import type test (JSON5)', function() {
@@ -188,6 +201,15 @@ describe('Import type test (JSON5)', function() {
 
     expect(result.css.toString()).to.eql('body {\n  color: ""; }\n');
   });
+
+  it('ignores variables starting with @, : or $', function() {
+    let result = sass.renderSync({
+      file: './test/fixtures-json5/invalid-variables/style.scss',
+      importer: jsonImporter,
+    });
+
+    expect(result.css.toString()).to.eql('body {\n  color: ""; }\n');
+  });
 });
 
 describe('parseValue', function() {
@@ -219,5 +241,23 @@ describe('isJSONfile', function() {
 
   it('returns false if the given URL is not a JSON or JSON5 file', function() {
     expect(isJSONfile('/test/variables.not-json-or-json5')).to.be.false;
+  });
+});
+
+describe('isValidKey', function() {
+  it('returns false if the given key starts with @', function() {
+    expect(isValidKey('@invalid')).to.be.false;
+  });
+
+  it('returns false if the given key starts with :', function() {
+    expect(isValidKey(':invalid')).to.be.false;
+  });
+
+  it('returns false if the given key starts with $', function() {
+    expect(isValidKey('$invalid')).to.be.false;
+  });
+
+  it('returns true if the given key does not start with @, : or $', function() {
+    expect(isValidKey('valid')).to.be.true;
   });
 });


### PR DESCRIPTION
Certain characters have a special meaning in Sass. If a property starts with one of them, the SASS compiler crashes. Based on manual testing, I've found `@`, `:` and `$` to be problematic. `#`, `%` and hyphens in the middle of a name (e.g. `'test-test'`) seem to be ok.
This PR filters out properties which start with one of these characters.