### PR TITLE
Convert values containing commas inside of an object into strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.4
+* Convert values containing commas inside of an object into strings
+
 ## 3.1.3
 * Extend key filtering to nested maps
 

--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,8 @@ export function parseValue(value) {
     return parseMap(value);
   } else if (value === '') {
     return '""'; // Return explicitly an empty string (Sass would otherwise throw an error as the variable is set to nothing)
+  } else if (_.isString(value) && shouldWrapInStrings(value)) {
+    return '"' + value + '"'; // Sass throws an error if a value contains a comma and is not treated as a string
   } else {
     return value;
   }
@@ -74,6 +76,22 @@ export function parseMap(map) {
     .filter(key => isValidKey(key))
     .map(key => `${key}: ${parseValue(map[key])}`)
     .join(',')})`;
+}
+
+/**
+ * There are multiple SASS functions (e.g. hsl() oder rgb()) which receive comma-separated values
+ * (e.g. hsl(270, 60%, 70%)). These should not be wrapped in quotes. A string like "Tomorrow, I will
+ * write SASS" should be wrapped in quotes. This function checks if commas are used outside of SASS
+ * functions.
+ *
+ * @param input Input to check.
+ *
+ * @return {boolean} True = Should be wrapped in quotes.
+ */
+export function shouldWrapInStrings(input) {
+  const inputWithoutFunctions = input.replace(/[a-zA-Z]+\([^)]*\)/, "") // Remove functions
+
+  return inputWithoutFunctions.includes(',');
 }
 
 // Super-hacky: Override Babel's transpiled export to provide both

--- a/test/index.js
+++ b/test/index.js
@@ -226,8 +226,21 @@ describe('parseValue', function() {
   });
 
   it('returns the raw value if not an array, object or empty string', function() {
-    expect(123).to.eql(123);
+    expect(parseValue(123)).to.eql(123);
   });
+
+  it('wraps the value in an object in quotes if the value contains a comma outside of a function', function() {
+    expect(parseValue({
+      "key": "value with , somewhere",
+    })).to.eql('(key: "value with , somewhere")');
+  });
+
+  it('does not wrap the value in an object in quotes if the value contains a function', function() {
+    expect(parseValue({
+      "key": "hsl(270, 60%, 70%)",
+    })).to.eql('(key: hsl(270, 60%, 70%))');
+  });
+
   it('can parse nested maps with invalid keys', function() {
     const nestedWithInvalid = {
       inner: {


### PR DESCRIPTION
We ran into an issue with the following code:

```js
{
    "key": "value with , somewhere",
}
```

This results in:
```sass
(key: value with , somewhere)
```
which makes SASS fail.

This PR converts values outside of a function which contain a comma into a string to avoid that. 

The new outcome is:
```sass
(key: "value with , somewhere")
```

If the input contains a function, it is not wrapped in strings:
**Input:**
```js
{
    "key": "hsl(270, 60%, 70%)",
}
```

**Output:**
```sass
(key: hsl(270, 60%, 70%))
```