### PR TITLE
Extend key filtering to nested maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.3
+* Extend key filtering to nested maps
+
 ## 3.1.2
 * Filter out invalid variable names to prevent Sass compiler from crashing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sass-json-importer",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Allows importing json in sass files parsed by node-sass.",
   "main": "dist/node-sass-json-importer.js",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,7 @@ export function parseList(list) {
 
 export function parseMap(map) {
   return `(${Object.keys(map)
+    .filter(key => isValidKey(key))
     .map(key => `${key}: ${parseValue(map[key])}`)
     .join(',')})`;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -228,6 +228,17 @@ describe('parseValue', function() {
   it('returns the raw value if not an array, object or empty string', function() {
     expect(123).to.eql(123);
   });
+  it('can parse nested maps with invalid keys', function() {
+    const nestedWithInvalid = {
+      inner: {
+        ':problem1': 'value1',
+        '$problem2': 'value2',
+        '@problem3': 'value3',
+        valid: 'value4',
+      }
+    };
+    expect(parseValue(nestedWithInvalid)).to.eql('(inner: (valid: value4))');
+  });
 });
 
 describe('isJSONfile', function() {


### PR DESCRIPTION
Hi,
thank you for your work! 
I want to suggest to filter invalid map keys also inside nested objects.