### PR TITLE
Don't wrap values containing only comma-separated variables into quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## 3.1.5
+* Don't wrap values containing only comma-separated variables into quotes
+
 ## 3.1.4
-* Convert values containing commas inside of an object into strings
+* Convert values containing commas inside of an object into quotes
 
 ## 3.1.3
 * Extend key filtering to nested maps

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sass-json-importer",
-  "version": "3.1.3",
+  "version": "3.1.5",
   "description": "Allows importing json in sass files parsed by node-sass.",
   "main": "dist/node-sass-json-importer.js",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -84,14 +84,31 @@ export function parseMap(map) {
  * write SASS" should be wrapped in quotes. This function checks if commas are used outside of SASS
  * functions.
  *
- * @param input Input to check.
+ * @param {string} input Input to check.
  *
  * @return {boolean} True = Should be wrapped in quotes.
  */
 export function shouldWrapInStrings(input) {
   const inputWithoutFunctions = input.replace(/[a-zA-Z]+\([^)]*\)/, "") // Remove functions
 
+  if (containsOnlyCommaSeparatedVariables(inputWithoutFunctions)) {
+    return false;
+  }
+
   return inputWithoutFunctions.includes(',');
+}
+
+/**
+ * Checks if the input contains only comma-separated variables ($abc).
+ *
+ * @param {string} input Input to check.
+ *
+ * @returns {boolean} True = Contains only comma-separated variables.
+ */
+export function containsOnlyCommaSeparatedVariables(input) {
+  const commaSeparatedParts = input.split(',');
+
+  return commaSeparatedParts.every(part => part.trim().startsWith('$'));
 }
 
 // Super-hacky: Override Babel's transpiled export to provide both

--- a/test/index.js
+++ b/test/index.js
@@ -231,14 +231,22 @@ describe('parseValue', function() {
 
   it('wraps the value in an object in quotes if the value contains a comma outside of a function', function() {
     expect(parseValue({
-      "key": "value with , somewhere",
+      'key': 'value with , somewhere',
     })).to.eql('(key: "value with , somewhere")');
   });
 
   it('does not wrap the value in an object in quotes if the value contains a function', function() {
     expect(parseValue({
-      "key": "hsl(270, 60%, 70%)",
+      'key': 'hsl(270, 60%, 70%)',
     })).to.eql('(key: hsl(270, 60%, 70%))');
+  });
+
+  it('does not wrap the value in an object in quotes if the value contains only comma-separated variables', function() {
+    const input = {
+      'someKey': '$variable, $variable2',
+    };
+
+    expect(parseValue(input)).to.eql('(someKey: $variable, $variable2)');
   });
 
   it('can parse nested maps with invalid keys', function() {


### PR DESCRIPTION
Hi,

we ran into a new issue with the latest changes. We do have a `fonts.json` file which contains entries like the following:
```js
    "font-preferred": "some-font",
    "font-fallback": "sans-serif",

    "font-family": "$font-preferred, $font-fallback",
```

Due to the previous PR I made, this is wrapped in quotes so that `$font-family` contains `"$font-preferred, $font-fallback"`. Instead, it should contain: `$font-preferred, $font-fallback` (not wrapped in quotes). This PR fixes this exact issue (object value containing only variables).

I wish there would be a better way to patch those things but I haven't found one...