### PR TITLE
Update package.json's main field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.1
+* Update package.json's main field (#73).
+
 ## 4.0.0
 * Add resolver option (ability to override how json file paths gets resolved) (#71).
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-sass-json-importer",
   "version": "4.0.0",
   "description": "Allows importing json in sass files parsed by node-sass.",
-  "main": "dist/node-sass-json-importer.js",
+  "main": "dist/index.js",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sass-json-importer",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Allows importing json in sass files parsed by node-sass.",
   "main": "dist/index.js",
   "license": "MIT",


### PR DESCRIPTION
@pmowrer  We've forgotten to update `package.json`'s `main` field.

Also, you probably had `node-sass-json-importer.js` in `dist` dir when publishing the package. Since I can see it after installing `node-sass-json-importer@4.0.0` (`node_modules/node-sass-json-importer/dist/node-sass-json-importer.js`).

And the tag for `4.0.0` release is missing. I don't think I can do anything about it.