### PR TITLE
Return fileName to have sass-loader handle dependency correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.1.0
+
+- Return `fileName` to have sass-loader handle dependency correctly (#74).
+
 ## 4.0.1
 * Update package.json's main field (#73).
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ export default function(options = {}) {
 
       return {
         contents: transformJSONtoSass(json),
+        file: fileName,
       };
     } catch(error) {
       return new Error(`node-sass-json-importer: Error transforming JSON/JSON5 to SASS. Check if your JSON/JSON5 parses correctly. ${error}`);

--- a/test/index.js
+++ b/test/index.js
@@ -20,6 +20,10 @@ describe('node-sass-json-importer', function() {
     });
 
     expect(result.css.toString()).to.eql(EXPECTATION);
+    expect(result.stats.includedFiles).to.eql([
+      resolve('./test/fixtures/strings/style.scss'),
+      resolve('./test/fixtures/strings/variables.json'),
+    ].sort());
   });
 
   // TODO: Added to verify named exports + CommonJS default export hack (see index.js).


### PR DESCRIPTION
Because sass-loader marks `file` as a dependency.

https://github.com/webpack-contrib/sass-loader/blob/bed9fb5799a90020d43f705ea405f85b368621d7/lib/loader.js#L75

A wrong dependency breaks dependencies graph.
As the result, it causes full-build even if we only changed one file which shouldn't trigger full-build.

Currently, [node-sass's document](https://github.com/sass/node-sass/tree/746759cc4def477a8594c49ef299a15aa2ed1746#importer--v200---experimental) says custom importer should return `file` or `contents` but actually it can both.

I sent a PR to fix document.

https://github.com/sass/node-sass/pull/2501